### PR TITLE
CTCP-3415 | Correct logging levels

### DIFF
--- a/app/connectors/ApiConnector.scala
+++ b/app/connectors/ApiConnector.scala
@@ -76,7 +76,7 @@ class ApiConnector @Inject() (httpClient: HttpClient, appConfig: AppConfig)(impl
           logger.info(s"ApiConnector:submitDeclaration: bad request: ${httpEx.responseCode}-${httpEx.getMessage}")
           Left(BadRequest("ApiConnector:submitDeclaration: bad request"))
         case e: Exception =>
-          logger.warn(s"ApiConnector:submitDeclaration: something went wrong: ${e.getMessage}")
+          logger.error(s"ApiConnector:submitDeclaration: something went wrong: ${e.getMessage}")
           Left(InternalServerError("ApiConnector:submitDeclaration: something went wrong"))
       }
   }

--- a/app/connectors/ApiConnector.scala
+++ b/app/connectors/ApiConnector.scala
@@ -54,7 +54,7 @@ class ApiConnector @Inject() (httpClient: HttpClient, appConfig: AppConfig)(impl
       }
       .recover {
         case e =>
-          logger.error(s"Failed to get departure movements with error: $e")
+          logger.warn(s"Failed to get departure movements with error: $e")
           None
       }
   }
@@ -64,7 +64,6 @@ class ApiConnector @Inject() (httpClient: HttpClient, appConfig: AppConfig)(impl
     val declarationUrl  = s"${appConfig.apiUrl}/movements/departures"
     val payload: String = Declaration.transformToXML(userAnswers).toString
 
-    // TODO - can we log and audit here and send a generic error to the FE?
     httpClient
       .POSTString[HttpResponse](declarationUrl, payload, requestHeaders)
       .map {
@@ -74,10 +73,10 @@ class ApiConnector @Inject() (httpClient: HttpClient, appConfig: AppConfig)(impl
       }
       .recover {
         case httpEx: BadRequestException =>
-          logger.warn(s"ApiConnector:submitDeclaration: bad request: ${httpEx.responseCode}-${httpEx.getMessage}")
+          logger.info(s"ApiConnector:submitDeclaration: bad request: ${httpEx.responseCode}-${httpEx.getMessage}")
           Left(BadRequest("ApiConnector:submitDeclaration: bad request"))
         case e: Exception =>
-          logger.error(s"ApiConnector:submitDeclaration: something went wrong: ${e.getMessage}")
+          logger.warn(s"ApiConnector:submitDeclaration: something went wrong: ${e.getMessage}")
           Left(InternalServerError("ApiConnector:submitDeclaration: something went wrong"))
       }
   }

--- a/app/controllers/CacheController.scala
+++ b/app/controllers/CacheController.scala
@@ -63,11 +63,11 @@ class CacheController @Inject() (
           if (request.eoriNumber == data.eoriNumber) {
             set(data)
           } else {
-            logger.error(s"Enrolment EORI (${request.eoriNumber}) does not match EORI in user answers (${data.eoriNumber})")
+            logger.warn(s"Enrolment EORI (${request.eoriNumber}) does not match EORI in user answers (${data.eoriNumber})")
             Future.successful(Forbidden)
           }
         case JsError(errors) =>
-          logger.error(s"Failed to validate request body as UserAnswers: $errors")
+          logger.warn(s"Failed to validate request body as UserAnswers: $errors")
           Future.successful(BadRequest)
       }
   }
@@ -77,7 +77,7 @@ class CacheController @Inject() (
       request.body.validate[String] match {
         case JsSuccess(lrn, _) => set(Metadata(lrn, request.eoriNumber))
         case JsError(errors) =>
-          logger.error(s"Failed to validate request body as String: $errors")
+          logger.warn(s"Failed to validate request body as String: $errors")
           Future.successful(BadRequest)
       }
   }

--- a/app/controllers/SubmissionController.scala
+++ b/app/controllers/SubmissionController.scala
@@ -55,7 +55,7 @@ class SubmissionController @Inject() (
             case None => Future.successful(InternalServerError)
           }
         case JsError(errors) =>
-          logger.error(s"Failed to validate request body as String: $errors")
+          logger.warn(s"Failed to validate request body as String: $errors")
           Future.successful(BadRequest)
       }
   }

--- a/app/controllers/XPathController.scala
+++ b/app/controllers/XPathController.scala
@@ -42,7 +42,7 @@ class XPathController @Inject() (
         case JsSuccess(xPaths, _) =>
           xPathService.isDeclarationAmendable(lrn, request.eoriNumber, xPaths).map(JsBoolean).map(Ok(_))
         case JsError(errors) =>
-          logger.error(s"Failed to validate request body as sequence of xPaths: $errors")
+          logger.warn(s"Failed to validate request body as sequence of xPaths: $errors")
           Future.successful(BadRequest)
       }
   }
@@ -53,7 +53,7 @@ class XPathController @Inject() (
         case JsSuccess(xPaths, _) =>
           xPathService.handleErrors(lrn, request.eoriNumber, xPaths).map(JsBoolean).map(Ok(_))
         case JsError(errors) =>
-          logger.error(s"Failed to validate request body as sequence of xPaths: $errors")
+          logger.warn(s"Failed to validate request body as sequence of xPaths: $errors")
           Future.successful(BadRequest)
       }
   }

--- a/app/controllers/testonly/TestOnlySubmissionController.scala
+++ b/app/controllers/testonly/TestOnlySubmissionController.scala
@@ -36,7 +36,7 @@ class TestOnlySubmissionController @Inject() (
         case JsSuccess(userAnswers, _) =>
           Ok(Declaration.transformToXML(userAnswers))
         case JsError(errors) =>
-          logger.error(s"Failed to validate request body as UserAnswers: ${errors.mkString}")
+          logger.info(s"Failed to validate request body as UserAnswers: ${errors.mkString}")
           BadRequest
       }
   }

--- a/app/services/XPathService.scala
+++ b/app/services/XPathService.scala
@@ -53,12 +53,12 @@ class XPathService @Inject() (
               .map {
                 case true => true
                 case false =>
-                  logger.error("Write was not acknowledged")
+                  logger.warn("Write was not acknowledged")
                   false
               }
               .recover {
                 case e =>
-                  logger.error("Failed to write user answers to mongo", e)
+                  logger.warn("Failed to write user answers to mongo", e)
                   false
               }
           case _ => Future.successful(false)


### PR DESCRIPTION
**Use the appropriate log level**

Error - for significant issues that you will cause someone to be woken up at night to fix, such as inability to perform the service's central responsibility. These should very rarely happen. An example is an OutOfMemoryError or IO error.

Warn - for significant issues that will get someone's attention. Examples include unexpected data returned from a dependent service.

Info - general information useful to someone monitoring the service, such as you do after a deploy. Examples include payload.

Debug - detailed information from internal methods used for developers. This must be switched off in Production and Staging.