### PR TITLE
CTCP-3337: Updating consignee and transport charges reads

### DIFF
--- a/app/api/submission/Address.scala
+++ b/app/api/submission/Address.scala
@@ -59,4 +59,14 @@ object addressType12 {
 
   implicit val optionalReads: Reads[Option[AddressType12]] =
     addressType.optionalReads(AddressType12)
+
+  implicit class RichAddressType12(value: AddressType12) {
+
+    def asAddressType17: AddressType17 = AddressType17(
+      streetAndNumber = value.streetAndNumber,
+      postcode = value.postcode,
+      city = value.city,
+      country = value.country
+    )
+  }
 }

--- a/app/api/submission/Consignment.scala
+++ b/app/api/submission/Consignment.scala
@@ -174,7 +174,7 @@ object consigneeType05 {
     for {
       items <- itemsPath.read[JsArray]
       consignees = items.value.flatMap {
-        _.validate((__ \ "consignee").read[ConsigneeType02](consigneeType02.reads).map(_.asConsigneeType05)).asOpt
+        _.validate(itemConsigneePath.read[ConsigneeType02](consigneeType02.reads).map(_.asConsigneeType05)).asOpt
       }.toSeq
     } yield consignees match {
       case head :: tail => if (tail.forall(_ == head)) Some(head) else None
@@ -463,7 +463,7 @@ object consignmentItemType09 {
             (__ \ "countryOfDispatch" \ "code").readNullable[String] and
             (__ \ "countryOfDestination" \ "code").readNullable[String] and
             (__ \ "uniqueConsignmentReference").readNullable[String] and
-            (__ \ "consignee").readNullable[ConsigneeType02](consigneeType02.reads) and
+            itemConsigneePath.readNullable[ConsigneeType02](consigneeType02.reads) and
             (__ \ "supplyChainActors").readArray[AdditionalSupplyChainActorType](additionalSupplyChainActorType.reads) and
             __.read[CommodityType06](commodityType06.reads) and
             (__ \ "packages").readArray[PackagingType03](packagingType03.reads) and

--- a/app/api/submission/package.scala
+++ b/app/api/submission/package.scala
@@ -44,7 +44,8 @@ package object submission {
 
   lazy val documentsPath: JsPath = __ \ "documents" \ "documents"
 
-  lazy val itemsPath: JsPath = __ \ "items"
+  lazy val itemsPath: JsPath         = __ \ "items"
+  lazy val itemConsigneePath: JsPath = __ \ "consignee"
 
   lazy val reducedDatasetIndicatorReads: Reads[Boolean] =
     (consignmentPath \ "approvedOperator").readWithDefault[Boolean](false)

--- a/test/submission/ConsignmentSpec.scala
+++ b/test/submission/ConsignmentSpec.scala
@@ -1438,5 +1438,148 @@ class ConsignmentSpec extends SpecBase {
         )
       }
     }
+
+    "consigneeType05 reads is called" when {
+      "consignee defined at consignment level" in {
+        val json = Json.parse("""
+            |{
+            |  "traderDetails" : {
+            |    "consignment" : {
+            |      "consignee" : {
+            |        "eori" : "consignee1",
+            |        "name" : "Connor Signee",
+            |        "country" : {
+            |          "code" : "GB",
+            |          "description" : "United Kingdom"
+            |        },
+            |        "address" : {
+            |          "numberAndStreet" : "1 Test Lane",
+            |          "city" : "Testville",
+            |          "postalCode" : "TE1 1ST"
+            |        }
+            |      }
+            |    }
+            |  }
+            |}
+            |""".stripMargin)
+
+        val result = json.as[Option[ConsigneeType05]](consigneeType05.reads)
+
+        result.value shouldBe ConsigneeType05(
+          identificationNumber = Some("consignee1"),
+          name = Some("Connor Signee"),
+          Address = Some(
+            AddressType17(
+              streetAndNumber = "1 Test Lane",
+              postcode = Some("TE1 1ST"),
+              city = "Testville",
+              country = "GB"
+            )
+          )
+        )
+      }
+
+      "consignee undefined at consignment level" when {
+        "items have same consignee" in {
+          val json = Json.parse("""
+              |{
+              |  "items" : [
+              |    {
+              |      "consignee" : {
+              |        "addConsigneeEoriNumberYesNo" : true,
+              |        "identificationNumber" : "consignee1",
+              |        "name" : "Connor Signee",
+              |        "country" : {
+              |          "code" : "GB",
+              |          "description" : "United Kingdom"
+              |        },
+              |        "address" : {
+              |          "numberAndStreet" : "1 Test Lane",
+              |          "city" : "Testville",
+              |          "postalCode" : "TE1 1ST"
+              |        }
+              |      }
+              |    },
+              |    {
+              |      "consignee" : {
+              |        "addConsigneeEoriNumberYesNo" : true,
+              |        "identificationNumber" : "consignee1",
+              |        "name" : "Connor Signee",
+              |        "country" : {
+              |          "code" : "GB",
+              |          "description" : "United Kingdom"
+              |        },
+              |        "address" : {
+              |          "numberAndStreet" : "1 Test Lane",
+              |          "city" : "Testville",
+              |          "postalCode" : "TE1 1ST"
+              |        }
+              |      }
+              |    }
+              |  ]
+              |}
+              |""".stripMargin)
+
+          val result = json.as[Option[ConsigneeType05]](consigneeType05.reads)
+
+          result.value shouldBe ConsigneeType05(
+            identificationNumber = Some("consignee1"),
+            name = Some("Connor Signee"),
+            Address = Some(
+              AddressType17(
+                streetAndNumber = "1 Test Lane",
+                postcode = Some("TE1 1ST"),
+                city = "Testville",
+                country = "GB"
+              )
+            )
+          )
+        }
+
+        "items have different consignees" in {
+          val json = Json.parse("""
+              |{
+              |  "items" : [
+              |    {
+              |      "consignee" : {
+              |        "addConsigneeEoriNumberYesNo" : true,
+              |        "identificationNumber" : "consignee1",
+              |        "name" : "Connor Signee",
+              |        "country" : {
+              |          "code" : "GB",
+              |          "description" : "United Kingdom"
+              |        },
+              |        "address" : {
+              |          "numberAndStreet" : "1 Test Lane",
+              |          "city" : "Testville",
+              |          "postalCode" : "TE1 1ST"
+              |        }
+              |      }
+              |    },
+              |    {
+              |      "consignee" : {
+              |        "addConsigneeEoriNumberYesNo" : false,
+              |        "name" : "Joe Bloggs",
+              |        "country" : {
+              |          "code" : "FR",
+              |          "description" : "France"
+              |        },
+              |        "address" : {
+              |          "numberAndStreet" : "1 Test Rue",
+              |          "city" : "Paris",
+              |          "postalCode" : "PA1 1PA"
+              |        }
+              |      }
+              |    }
+              |  ]
+              |}
+              |""".stripMargin)
+
+          val result = json.as[Option[ConsigneeType05]](consigneeType05.reads)
+
+          result shouldBe None
+        }
+      }
+    }
   }
 }

--- a/test/submission/ConsignmentSpec.scala
+++ b/test/submission/ConsignmentSpec.scala
@@ -1439,143 +1439,74 @@ class ConsignmentSpec extends SpecBase {
       }
     }
 
-    "consigneeType05 reads is called" when {
-      "consignee defined at consignment level" in {
+    "transportChargesType reads is called" when {
+      "transport charges defined at consignment level" in {
         val json = Json.parse("""
             |{
-            |  "traderDetails" : {
-            |    "consignment" : {
-            |      "consignee" : {
-            |        "eori" : "consignee1",
-            |        "name" : "Connor Signee",
-            |        "country" : {
-            |          "code" : "GB",
-            |          "description" : "United Kingdom"
-            |        },
-            |        "address" : {
-            |          "numberAndStreet" : "1 Test Lane",
-            |          "city" : "Testville",
-            |          "postalCode" : "TE1 1ST"
-            |        }
-            |      }
+            |  "transportDetails" : {
+            |    "equipmentsAndCharges" : {
+            |      "paymentMethod" : "cash"
             |    }
             |  }
             |}
             |""".stripMargin)
 
-        val result = json.as[Option[ConsigneeType05]](consigneeType05.reads)
+        val result = json.as[Option[TransportChargesType]](transportChargesType.reads)
 
-        result.value shouldBe ConsigneeType05(
-          identificationNumber = Some("consignee1"),
-          name = Some("Connor Signee"),
-          Address = Some(
-            AddressType17(
-              streetAndNumber = "1 Test Lane",
-              postcode = Some("TE1 1ST"),
-              city = "Testville",
-              country = "GB"
-            )
-          )
+        result.value shouldBe TransportChargesType(
+          methodOfPayment = "A"
         )
       }
 
-      "consignee undefined at consignment level" when {
-        "items have same consignee" in {
+      "transport charges undefined at consignment level" when {
+        "items have same transport charges" in {
           val json = Json.parse("""
               |{
               |  "items" : [
               |    {
-              |      "consignee" : {
-              |        "addConsigneeEoriNumberYesNo" : true,
-              |        "identificationNumber" : "consignee1",
-              |        "name" : "Connor Signee",
-              |        "country" : {
-              |          "code" : "GB",
-              |          "description" : "United Kingdom"
-              |        },
-              |        "address" : {
-              |          "numberAndStreet" : "1 Test Lane",
-              |          "city" : "Testville",
-              |          "postalCode" : "TE1 1ST"
-              |        }
+              |      "methodOfPayment" : {
+              |        "code" : "A",
+              |        "description" : "Payment in cash"
               |      }
               |    },
               |    {
-              |      "consignee" : {
-              |        "addConsigneeEoriNumberYesNo" : true,
-              |        "identificationNumber" : "consignee1",
-              |        "name" : "Connor Signee",
-              |        "country" : {
-              |          "code" : "GB",
-              |          "description" : "United Kingdom"
-              |        },
-              |        "address" : {
-              |          "numberAndStreet" : "1 Test Lane",
-              |          "city" : "Testville",
-              |          "postalCode" : "TE1 1ST"
-              |        }
+              |      "methodOfPayment" : {
+              |        "code" : "A",
+              |        "description" : "Payment in cash"
               |      }
               |    }
               |  ]
               |}
               |""".stripMargin)
 
-          val result = json.as[Option[ConsigneeType05]](consigneeType05.reads)
+          val result = json.as[Option[TransportChargesType]](transportChargesType.reads)
 
-          result.value shouldBe ConsigneeType05(
-            identificationNumber = Some("consignee1"),
-            name = Some("Connor Signee"),
-            Address = Some(
-              AddressType17(
-                streetAndNumber = "1 Test Lane",
-                postcode = Some("TE1 1ST"),
-                city = "Testville",
-                country = "GB"
-              )
-            )
+          result.value shouldBe TransportChargesType(
+            methodOfPayment = "A"
           )
         }
 
-        "items have different consignees" in {
+        "items have different transport charges" in {
           val json = Json.parse("""
               |{
               |  "items" : [
               |    {
-              |      "consignee" : {
-              |        "addConsigneeEoriNumberYesNo" : true,
-              |        "identificationNumber" : "consignee1",
-              |        "name" : "Connor Signee",
-              |        "country" : {
-              |          "code" : "GB",
-              |          "description" : "United Kingdom"
-              |        },
-              |        "address" : {
-              |          "numberAndStreet" : "1 Test Lane",
-              |          "city" : "Testville",
-              |          "postalCode" : "TE1 1ST"
-              |        }
+              |      "methodOfPayment" : {
+              |        "code" : "A",
+              |        "description" : "Payment in cash"
               |      }
               |    },
               |    {
-              |      "consignee" : {
-              |        "addConsigneeEoriNumberYesNo" : false,
-              |        "name" : "Joe Bloggs",
-              |        "country" : {
-              |          "code" : "FR",
-              |          "description" : "France"
-              |        },
-              |        "address" : {
-              |          "numberAndStreet" : "1 Test Rue",
-              |          "city" : "Paris",
-              |          "postalCode" : "PA1 1PA"
-              |        }
+              |      "methodOfPayment" : {
+              |        "code" : "B",
+              |        "description" : "Payment by credit card"
               |      }
               |    }
               |  ]
               |}
               |""".stripMargin)
 
-          val result = json.as[Option[ConsigneeType05]](consigneeType05.reads)
+          val result = json.as[Option[TransportChargesType]](transportChargesType.reads)
 
           result shouldBe None
         }


### PR DESCRIPTION
Confirmed with Sayak that "There will be a validation at item level to check if consignee info is present at consignment level. Same for transport charges"
Therefore in the reads we can check first for a value at the consignment level. If there isn't one, we check each item in turn and see if they all contain the same consignee/transport charges. If they do, these bubble up to the consignment level.