### PR TITLE
CTCP-5987

### DIFF
--- a/app/services/XPathService.scala
+++ b/app/services/XPathService.scala
@@ -16,9 +16,9 @@
 
 package services
 
+import models.*
 import models.Rejection.BusinessRejectionType
-import models.Task._
-import models._
+import models.Task.*
 import play.api.Logging
 import repositories.CacheRepository
 
@@ -31,7 +31,11 @@ class XPathService @Inject() (
     extends Logging {
 
   def isDeclarationAmendable(lrn: String, eoriNumber: String, xPaths: Seq[XPath]): Future[Boolean] =
-    cacheRepository.get(lrn, eoriNumber).map(_.isDefined && xPaths.exists(_.isAmendable))
+    cacheRepository.get(lrn, eoriNumber).map {
+      _.exists {
+        _.status != SubmissionState.NotSubmitted && xPaths.exists(_.isAmendable)
+      }
+    }
 
   def handleRejection(userAnswers: UserAnswers, rejection: Rejection): UserAnswers =
     rejection match {


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/CTCP-5987

Declaration is not amendable if they are submitting a new IE015.

Scenario:

1. User submits an IE015
2. ERMIS responds with IE056 with amendable errors
3. 30 days pass and document expires
4. User goes to departure status tracking page
5. Status should be 'View errors' because they can't amend (there's nothing in the cache for them to amend)
6. User clicks 'Make another departure declaration' and enters the same LRN
7. Draft saved to the cache for that LRN with status NotSubmitted
8. User returns to departure status tracking page
9. Status remains 'View errors' because the status is NotSubmitted (previously it would have shown 'Amend declaration')