### PR TITLE
Upgrade libraries: sbt-plugin → 3.0.10, bootstrap-backend-play-30 → 10.6.0

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object AppDependencies {
 
   private val mongoVersion = "2.12.0"
-  private val bootstrapVersion = "10.5.0"
+  private val bootstrapVersion = "10.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.9")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.10")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.2.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.3")
 addSbtPlugin("org.scalaxb"       % "sbt-scalaxb"        % "1.12.1" exclude("org.scala-lang.modules", "scala-xml_2.12"))


### PR DESCRIPTION
## Library Upgrades

| Group | Artifact | New Version |
|-------|----------|-------------|
| `org.playframework` | `sbt-plugin` | `3.0.10` |
| `uk.gov.hmrc` | `bootstrap-backend-play-30` | `10.6.0` |